### PR TITLE
Added support for manual entity "naming" in the hierarchy

### DIFF
--- a/Runtime/EditorHelpers.cs
+++ b/Runtime/EditorHelpers.cs
@@ -71,15 +71,18 @@ namespace Leopotam.EcsLite.UnityEditor {
         static Type[] _componentTypesCache = new Type[32];
 
         Transform _entitiesRoot;
+
+        private bool _autoName = true;
         // Transform _filtersRoot;
         
-        public static GameObject Create (EcsWorld world, string name = null) {
+        public static GameObject Create (EcsWorld world, string name = null, bool autoName = true) {
             if (world == null) { throw new ArgumentNullException (nameof (world)); }
             var go = new GameObject (name != null ? $"[ECS-WORLD {name}]" : "[ECS-WORLD]");
             DontDestroyOnLoad (go);
             go.hideFlags = HideFlags.NotEditable;
             var observer = go.AddComponent<EcsWorldObserver> ();
             observer._world = world;
+            observer._autoName = autoName;
             var worldTr = observer.transform;
             // entities root.
             observer._entitiesRoot = new GameObject ("Entities").transform;
@@ -116,7 +119,8 @@ namespace Leopotam.EcsLite.UnityEditor {
         }
 
         public void OnEntityChanged (int entity) {
-            UpdateEntityName (entity, true);
+            if (_autoName)
+                UpdateEntityName (entity, true);
         }
 
         public void OnEntityDestroyed (int entity) {

--- a/Runtime/UnityDebugName.cs
+++ b/Runtime/UnityDebugName.cs
@@ -1,0 +1,102 @@
+﻿using Leopotam.EcsLite.UnityEditor;
+using UnityEngine;
+
+namespace Leopotam.EcsLite
+{
+	public struct UnityDebugName
+	{
+		public string DisplayName;
+
+		public bool changed;
+	}
+	
+	public static class UnityDebugNamingExt
+	{
+		/// <summary>
+		/// Creates a new entity.  If running inside the unity editor, the passed name will be used
+		/// in the debug hierarchy.  (In builds, this is ignored)
+		/// </summary>
+		public static int NewEntity(this EcsWorld world, string entityName)
+		{
+			int result = world.NewEntity();
+#if UNITY_EDITOR
+			ref UnityDebugName nameComponent = ref world.GetPool<UnityDebugName>().Add(result);
+			nameComponent.DisplayName = entityName;
+			nameComponent.changed = true;
+#endif
+			return result;
+		}
+		
+		/// <summary>
+		/// Sets the debug name shown for an entity in the debug hierarchy, if running
+		/// inside the unity editor. (In builds, this is ignored)
+		/// </summary>
+		public static void UpdateEntityName(this EcsWorld world, int entity, string entityName)
+		{
+#if UNITY_EDITOR
+			var pool = world.GetPool<UnityDebugName>();
+			ref UnityDebugName nameComponent = ref pool.GetOrCreate(entity);
+			nameComponent.DisplayName = entityName;
+			nameComponent.changed = true;
+#endif
+		}
+		
+	
+		private static ref T GetOrCreate<T>(this EcsPool<T> self, int entity) where T : struct
+		{
+			if (!self.Has(entity))
+			{
+				return ref self.Add(entity);
+			}
+
+			return ref self.Get(entity);
+		}
+	}
+	
+	/// <summary>
+	/// Handles integrating entity names into the Unity Hierarchy.  Should only be added
+	/// under a `#if UNITY_EDITOR` context.
+	/// </summary>
+	public class UnityDebugEntityNameUpdater : IEcsRunSystem, IEcsInitSystem
+	{
+		private readonly EcsWorldObserver _observer;
+		private EcsWorld _world;
+		private EcsPool<UnityDebugName> _namePool;
+		private EcsFilter _filter;
+
+		
+		/// <summary>
+		/// Creates the name updater for a particular world.  Takes an EcsWorldObserver, but
+		/// most of the time the simply provide the output of the `EcsWorldObserver.Create` call.
+		/// </summary>
+		public UnityDebugEntityNameUpdater(EcsWorldObserver observer)
+		{
+			_observer = observer;
+		}
+		
+		/// <summary>
+		/// Creates the name updater for a particular world.  Takes the output of the
+		/// `EcsWorldObserver.Create` call. 
+		/// </summary>
+		public UnityDebugEntityNameUpdater(GameObject observer) : this(observer.GetComponent<EcsWorldObserver>())
+		{
+		}
+			
+		public void Init(EcsSystems systems)
+		{
+			_world = systems.GetWorld();
+			_namePool = _world.GetPool<UnityDebugName>();
+			_filter = _world.Filter<UnityDebugName>().End();
+		}
+			
+		public void Run(EcsSystems systems)
+		{
+			foreach (var entity in _filter)
+			{
+				ref UnityDebugName nameComponent = ref _namePool.Get(entity);
+				if (nameComponent.changed)
+					_observer.EntityGameObjects[entity].name = nameComponent.DisplayName;
+			}
+		}
+	}
+}

--- a/Runtime/UnityDebugName.cs.meta
+++ b/Runtime/UnityDebugName.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 67fd943a82054163ae5634d943a0c55d
+timeCreated: 1624128570


### PR DESCRIPTION
This can work around situations with lots of component add/del, where using reactive naming results in poor performance.

As discussed on the discord, using flag components causes severe performance loss inside of the Unity Editor as the EcsWorldObserver reacts immediately.  Each flag component being added and removed in the same frame cause two rename attempts with the associated allocations.

This pull request performs two things:

### 1. Makes reactive naming optional on a EcsWorldObserver basis.
With the changes to EditorHelpers.cs, a new optional parameter has been added to indicate if reactive autonaming should be used:
```cs
EcsWorldObserver.Create (_ecsWorld, "GameWorld", false);
```

Default is the existing behavior.  If disabled, then the objects appear in the hierarchy as ECS00001, ECS00002.

### 2. Added system and extension methods to permit manually setting the name to be displayed
The changes in the UnityDebugName.cs adds a new system that can be added like so:

```cs
#if UNITY_EDITOR
    var worldObserver = EcsWorldObserver.Create (_ecsWorld, "GameWorld", false);
#endif

...

_systems = new EcsSystems(_ecsWorld, <shared>)

#if UNITY_EDITOR
	.Add(new UnityDebugEntityNameUpdater(worldObserver))
#endif
```

Then, using the extension methods, the user can manually name entities:

```cs
//naming on creation
_gameWorld.NewEntity("Flagship");

...

//renaming later, based on status change
_gameWorld.UpdateEntityName(entity, "Flagship (dying)");
```


The idea is to give the developer the ability to manually name entities without changing the current default behavior.   This provides both utility, and a workaround to performance issues with reactive naming.



