### PR TITLE
Simplify inspectors

### DIFF
--- a/Editor/EcsEntityDebugView.cs
+++ b/Editor/EcsEntityDebugView.cs
@@ -167,6 +167,6 @@ namespace Leopotam.EcsLite.UnityEditor {
             return (default, default);
         }
 
-        public abstract bool OnGuiTyped (string label, ref T value, EcsEntityDebugView entityView);
+        public abstract void OnGuiTyped (string label, ref T value, EcsEntityDebugView entityView);
     }
 }

--- a/Editor/EcsEntityDebugView.cs
+++ b/Editor/EcsEntityDebugView.cs
@@ -159,8 +159,9 @@ namespace Leopotam.EcsLite.UnityEditor {
                 return (default, default);
             }
             var typedValue = (T) value;
-            var changed = OnGuiTyped (label, ref typedValue, entityView);
-            if (changed) {
+            EditorGUI.BeginChangeCheck();
+            OnGuiTyped (label, ref typedValue, entityView);
+            if (EditorGUI.EndChangeCheck()) {
                 return (true, typedValue);
             }
             return (default, default);

--- a/Editor/Inspectors/Ecs/EcsPackedEntity.cs
+++ b/Editor/Inspectors/Ecs/EcsPackedEntity.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class EcsPackedEntityInspector : EcsComponentInspectorTyped<EcsPackedEntity> {
-        public override bool OnGuiTyped (string label, ref EcsPackedEntity value, EcsEntityDebugView entityView) {
+        public override void OnGuiTyped (string label, ref EcsPackedEntity value, EcsEntityDebugView entityView) {
             EditorGUILayout.BeginHorizontal ();
             EditorGUILayout.PrefixLabel (label);
             if (value.Unpack (entityView.World, out var unpackedEntity)) {
@@ -23,7 +23,6 @@ namespace Leopotam.EcsLite.UnityEditor.Inspectors {
                 }
             }
             EditorGUILayout.EndHorizontal ();
-            return false;
         }
     }
 }

--- a/Editor/Inspectors/Ecs/EcsPackedEntityWithWorld.cs
+++ b/Editor/Inspectors/Ecs/EcsPackedEntityWithWorld.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class EcsPackedEntityWithWorldInspector : EcsComponentInspectorTyped<EcsPackedEntityWithWorld> {
-        public override bool OnGuiTyped (string label, ref EcsPackedEntityWithWorld value, EcsEntityDebugView entityView) {
+        public override void OnGuiTyped (string label, ref EcsPackedEntityWithWorld value, EcsEntityDebugView entityView) {
             EditorGUILayout.BeginHorizontal ();
             EditorGUILayout.PrefixLabel (label);
             if (value.Unpack (out var unpackedWorld, out var unpackedEntity)) {
@@ -27,7 +27,6 @@ namespace Leopotam.EcsLite.UnityEditor.Inspectors {
                 }
             }
             EditorGUILayout.EndHorizontal ();
-            return false;
         }
     }
 }

--- a/Editor/Inspectors/System/Bool.cs
+++ b/Editor/Inspectors/System/Bool.cs
@@ -7,11 +7,8 @@ using UnityEditor;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class BoolInspector : EcsComponentInspectorTyped<bool> {
-        public override bool OnGuiTyped (string label, ref bool value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.Toggle (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref bool value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.Toggle (label, value);
         }
     }
 }

--- a/Editor/Inspectors/System/Double.cs
+++ b/Editor/Inspectors/System/Double.cs
@@ -7,11 +7,8 @@ using UnityEditor;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class DoubleInspector : EcsComponentInspectorTyped<double> {
-        public override bool OnGuiTyped (string label, ref double value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.DoubleField (label, value);
-            if (System.Math.Abs (newValue - value) < double.Epsilon) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref double value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.DoubleField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/System/Float.cs
+++ b/Editor/Inspectors/System/Float.cs
@@ -7,11 +7,8 @@ using UnityEditor;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class FloatInspector : EcsComponentInspectorTyped<float> {
-        public override bool OnGuiTyped (string label, ref float value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.FloatField (label, value);
-            if (System.Math.Abs (newValue - value) < float.Epsilon) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref float value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.FloatField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/System/Int.cs
+++ b/Editor/Inspectors/System/Int.cs
@@ -7,11 +7,8 @@ using UnityEditor;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class IntInspector : EcsComponentInspectorTyped<int> {
-        public override bool OnGuiTyped (string label, ref int value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.IntField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref int value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.IntField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/System/Long.cs
+++ b/Editor/Inspectors/System/Long.cs
@@ -7,11 +7,8 @@ using UnityEditor;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class LongInspector : EcsComponentInspectorTyped<long> {
-        public override bool OnGuiTyped (string label, ref long value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.LongField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref long value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.LongField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/System/String.cs
+++ b/Editor/Inspectors/System/String.cs
@@ -11,11 +11,8 @@ namespace Leopotam.EcsLite.UnityEditor.Inspectors {
             return true;
         }
 
-        public override bool OnGuiTyped (string label, ref string value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.TextField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref string value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.TextField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/AnimationCurve.cs
+++ b/Editor/Inspectors/Unity/AnimationCurve.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class AnimationCurveInspector : EcsComponentInspectorTyped<AnimationCurve> {
-        public override bool OnGuiTyped (string label, ref AnimationCurve value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.CurveField (label, value);
-            if (newValue.Equals (value)) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref AnimationCurve value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.CurveField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Bounds.cs
+++ b/Editor/Inspectors/Unity/Bounds.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class BoundsInspector : EcsComponentInspectorTyped<Bounds> {
-        public override bool OnGuiTyped (string label, ref Bounds value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.BoundsField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Bounds value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.BoundsField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/BoundsInt.cs
+++ b/Editor/Inspectors/Unity/BoundsInt.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class BoundsIntInspector : EcsComponentInspectorTyped<BoundsInt> {
-        public override bool OnGuiTyped (string label, ref BoundsInt value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.BoundsIntField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref BoundsInt value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.BoundsIntField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Color.cs
+++ b/Editor/Inspectors/Unity/Color.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class ColorInspector : EcsComponentInspectorTyped<Color> {
-        public override bool OnGuiTyped (string label, ref Color value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.ColorField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Color value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.ColorField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Color32.cs
+++ b/Editor/Inspectors/Unity/Color32.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class Color32Inspector : EcsComponentInspectorTyped<Color32> {
-        public override bool OnGuiTyped (string label, ref Color32 value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.ColorField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Color32 value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.ColorField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Gradient.cs
+++ b/Editor/Inspectors/Unity/Gradient.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class GradientInspector : EcsComponentInspectorTyped<Gradient> {
-        public override bool OnGuiTyped (string label, ref Gradient value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.GradientField (label, value);
-            if (newValue.Equals (value)) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Gradient value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.GradientField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/LayerMask.cs
+++ b/Editor/Inspectors/Unity/LayerMask.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class LayerMaskInspector : EcsComponentInspectorTyped<LayerMask> {
-        public override bool OnGuiTyped (string label, ref LayerMask value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.LayerField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref LayerMask value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.LayerField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Quaternion.cs
+++ b/Editor/Inspectors/Unity/Quaternion.cs
@@ -8,12 +8,9 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class QuaternionInspector : EcsComponentInspectorTyped<Quaternion> {
-        public override bool OnGuiTyped (string label, ref Quaternion value, EcsEntityDebugView entityView) {
+        public override void OnGuiTyped (string label, ref Quaternion value, EcsEntityDebugView entityView) {
             var eulerAngles = value.eulerAngles;
-            var newValue = EditorGUILayout.Vector3Field (label, eulerAngles);
-            if (newValue == eulerAngles) { return false; }
-            value = Quaternion.Euler (newValue);
-            return true;
+            value = Quaternion.Euler(EditorGUILayout.Vector3Field (label, eulerAngles));
         }
     }
 }

--- a/Editor/Inspectors/Unity/Rect.cs
+++ b/Editor/Inspectors/Unity/Rect.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class RectInspector : EcsComponentInspectorTyped<Rect> {
-        public override bool OnGuiTyped (string label, ref Rect value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.RectField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Rect value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.RectField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Vector2.cs
+++ b/Editor/Inspectors/Unity/Vector2.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class Vector2Inspector : EcsComponentInspectorTyped<Vector2> {
-        public override bool OnGuiTyped (string label, ref Vector2 value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.Vector2Field (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Vector2 value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.Vector2Field (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Vector2Int.cs
+++ b/Editor/Inspectors/Unity/Vector2Int.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class Vector2IntInspector : EcsComponentInspectorTyped<Vector2Int> {
-        public override bool OnGuiTyped (string label, ref Vector2Int value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.Vector2IntField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Vector2Int value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.Vector2IntField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Vector3.cs
+++ b/Editor/Inspectors/Unity/Vector3.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class Vector3Inspector : EcsComponentInspectorTyped<Vector3> {
-        public override bool OnGuiTyped (string label, ref Vector3 value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.Vector3Field (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Vector3 value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.Vector3Field (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Vector3Int.cs
+++ b/Editor/Inspectors/Unity/Vector3Int.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class Vector3IntInspector : EcsComponentInspectorTyped<Vector3Int> {
-        public override bool OnGuiTyped (string label, ref Vector3Int value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.Vector3IntField (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Vector3Int value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.Vector3IntField (label, value);
         }
     }
 }

--- a/Editor/Inspectors/Unity/Vector4.cs
+++ b/Editor/Inspectors/Unity/Vector4.cs
@@ -8,11 +8,8 @@ using UnityEngine;
 
 namespace Leopotam.EcsLite.UnityEditor.Inspectors {
     sealed class Vector4Inspector : EcsComponentInspectorTyped<Vector4> {
-        public override bool OnGuiTyped (string label, ref Vector4 value, EcsEntityDebugView entityView) {
-            var newValue = EditorGUILayout.Vector4Field (label, value);
-            if (newValue == value) { return false; }
-            value = newValue;
-            return true;
+        public override void OnGuiTyped (string label, ref Vector4 value, EcsEntityDebugView entityView) {
+            value = EditorGUILayout.Vector4Field (label, value);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -135,15 +135,10 @@ public struct C2 {
 // Файл должен лежать где-то в проекте - будет обнаружен и подключен автоматически.
 #if UNITY_EDITOR
 sealed class C2Inspector : EcsComponentInspectorTyped<C2> {
-    public override bool OnGuiTyped (string label, ref C2 value, EcsEntityDebugView entityView) {
+    public override void OnGuiTyped (string label, ref C2 value, EcsEntityDebugView entityView) {
         EditorGUILayout.LabelField ($"Super C2 component", EditorStyles.boldLabel);
-        var newValue = EditorGUILayout.TextField ("Name", value.Name);
+        value.Name = EditorGUILayout.TextField ("Name", value.Name);
         EditorGUILayout.HelpBox ($"Hello, {value.Name}", MessageType.Info);
-        // Если значение не поменялось - возвращаем false.
-        if (newValue == value.Name) { return false; }
-        // Иначе - обновляем значение и возвращаем true.
-        value.Name = newValue;
-        return true;
     }
 }
 #endif


### PR DESCRIPTION
Simplify the way of writing inspectors for components with custom types.
This is achieved by using Unity's Editor.Begin/EndChangeCheck to detect value changes, instead of manual comparisons. In result, inspector code is much simpler.

Before:
```c#
public override bool OnGuiTyped (string label, ref bool value, EcsEntityDebugView entityView) {
    var newValue = EditorGUILayout.Toggle (label, value);
    if (newValue == value) { return false; }
    value = newValue;
    return true;
}
```
After:
```c#
public override void OnGuiTyped (string label, ref bool value, EcsEntityDebugView entityView) {
    value = EditorGUILayout.Toggle (label, value);
}
```